### PR TITLE
Add flag to control system metrics

### DIFF
--- a/collector/main.go
+++ b/collector/main.go
@@ -22,13 +22,14 @@ type mainCollector struct {
 	targetDesc *prometheus.Desc
 	targetUp   *prometheus.Desc
 	metrics    exportedMetrics
+	systemBeat bool
 }
 
 // HackfixRegex regex to replace JSON part
 var HackfixRegex = regexp.MustCompile("\"time\":(\\d+)") // replaces time:123 to time.ms:123, only filebeat has different naming of time metric
 
 // NewMainCollector constructor
-func NewMainCollector(client *http.Client, url *url.URL, name string, beatInfo *BeatInfo) prometheus.Collector {
+func NewMainCollector(client *http.Client, url *url.URL, name string, beatInfo *BeatInfo, systemBeat bool) prometheus.Collector {
 	instance := fmt.Sprintf("%s:%s", url.Hostname(), url.Port())
 	beat := &mainCollector{
 		Collectors: make(map[string]prometheus.Collector),
@@ -47,8 +48,9 @@ func NewMainCollector(client *http.Client, url *url.URL, name string, beatInfo *
 			nil,
 			nil),
 
-		beatInfo: beatInfo,
-		metrics:  exportedMetrics{},
+		beatInfo:   beatInfo,
+		metrics:    exportedMetrics{},
+		systemBeat: systemBeat,
 	}
 
 	beat.Collectors["system"] = NewSystemCollector(beatInfo, beat.Stats)
@@ -71,7 +73,9 @@ func (b *mainCollector) Describe(ch chan<- *prometheus.Desc) {
 	}
 
 	// standard collectors for all types of beats
-	b.Collectors["system"].Describe(ch)
+	if b.systemBeat {
+		b.Collectors["system"].Describe(ch)
+	}
 	b.Collectors["beat"].Describe(ch)
 	b.Collectors["libbeat"].Describe(ch)
 
@@ -104,7 +108,9 @@ func (b *mainCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	// standard collectors for all types of beats
-	b.Collectors["system"].Collect(ch)
+	if b.systemBeat {
+		b.Collectors["system"].Collect(ch)
+	}
 	b.Collectors["beat"].Collect(ch)
 	b.Collectors["libbeat"].Collect(ch)
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 		beatURI       = flag.String("beat.uri", "http://localhost:5066", "HTTP API address of beat.")
 		beatTimeout   = flag.Duration("beat.timeout", 10*time.Second, "Timeout for trying to get stats from beat.")
 		showVersion   = flag.Bool("version", false, "Show version and exit")
+		systemBeat    = flag.Bool("beat.system", false, "Expose system stats")
 	)
 	flag.Parse()
 
@@ -95,7 +96,7 @@ beatdiscovery:
 	// version metric
 	registry := prometheus.NewRegistry()
 	versionMetric := version.NewCollector(Name)
-	mainCollector := collector.NewMainCollector(httpClient, beatURL, Name, beatInfo)
+	mainCollector := collector.NewMainCollector(httpClient, beatURL, Name, beatInfo, *systemBeat)
 	registry.MustRegister(versionMetric)
 	registry.MustRegister(mainCollector)
 

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,8 @@ Configuration reference
 ```
 $ ./beat-exporter -help
 Usage of ./beat-exporter:
+  -beat.system
+        Expose system stats
   -beat.timeout duration
         Timeout for trying to get stats from beat. (default 10s)
   -beat.uri string


### PR DESCRIPTION
Add a boolean flag to enable system metrics. These duplicate metrics for
people running the Prometheus node_exporter. But allow it to be enabled
for users without node_exporter.

Signed-off-by: Ben Kochie <superq@gmail.com>