### PR TITLE
Add support for reporting the number of active Goroutines

### DIFF
--- a/collector/beat.go
+++ b/collector/beat.go
@@ -36,6 +36,10 @@ type BeatStats struct {
 		MemoryTotal float64 `json:"memory_total"`
 		RSS         float64 `json:"rss"`
 	} `json:"memstats"`
+
+	Runtime struct {
+		Goroutines uint64 `json:"goroutines"`
+	} `json:"runtime"`
 }
 
 type beatCollector struct {
@@ -142,6 +146,17 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 				),
 				eval: func(stats *Stats) float64 {
 					return stats.Beat.Memstats.RSS
+				},
+				valType: prometheus.GaugeValue,
+			},
+			{
+				desc: prometheus.NewDesc(
+					prometheus.BuildFQName(beatInfo.Beat, "runtime", "goroutines"),
+					"beat.runtime.goroutines",
+					nil, nil,
+				),
+				eval: func(stats *Stats) float64 {
+					return float64(stats.Beat.Runtime.Goroutines)
 				},
 				valType: prometheus.GaugeValue,
 			},


### PR DESCRIPTION
This PR adds a new metric to track the number of open Goroutines. This is exposed by the stats endpoint and it has proven useful for debugging purposes.