### PR TITLE
APM Server support

### DIFF
--- a/collector/apm_server.go
+++ b/collector/apm_server.go
@@ -1,0 +1,88 @@
+package collector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"reflect"
+	"strings"
+)
+
+type apmServerCollector struct {
+	beatInfo *BeatInfo
+	stats    *Stats
+	metrics  exportedMetrics
+}
+
+// NewApmServerCollector constructor
+func NewApmServerCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
+	return &apmServerCollector{
+		beatInfo: beatInfo,
+		stats:    stats,
+		metrics:  FlattenMetrics(beatInfo, stats.ApmServer, "", nil),
+	}
+}
+
+// Describe returns all descriptions of the collector.
+func (c *apmServerCollector) Describe(ch chan<- *prometheus.Desc) {
+
+	for _, metric := range c.metrics {
+		ch <- metric.desc
+	}
+
+}
+
+// Collect returns the current state of all metrics of the collector.
+func (c *apmServerCollector) Collect(ch chan<- prometheus.Metric) {
+
+	for _, i := range c.metrics {
+		ch <- prometheus.MustNewConstMetric(i.desc, i.valType, i.eval(c.stats))
+	}
+
+}
+
+// Transform ApmServer struct into flat structure
+func FlattenMetrics(beatInfo *BeatInfo, obj interface{}, prefix string, prefixArray []string) []exportedMetric {
+
+	var exported []exportedMetric
+
+	v := reflect.ValueOf(obj)
+	currentType := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).Kind() == reflect.Struct {
+			exported = append(exported, FlattenMetrics(beatInfo, v.Field(i).Interface(), prefix+formatMetricName(currentType.Field(i).Name)+"_", append(prefixArray, currentType.Field(i).Name))...)
+		} else {
+			var currentMetricName = currentType.Field(i).Name
+
+			var metric = exportedMetric{
+				desc: prometheus.NewDesc(
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), prefix[:len(prefix)-1], formatMetricName(currentMetricName)),
+					prefix+currentType.Field(i).Name,
+					nil, nil,
+				),
+				eval:    func(stats *Stats) float64 { return resolveStats(stats, append(prefixArray, currentMetricName)) },
+				valType: prometheus.CounterValue,
+			}
+			exported = append(exported, metric)
+		}
+
+	}
+	return exported
+}
+
+// Resolve stats by the array of prefix fields
+func resolveStats(stats *Stats, prefixArray []string) float64 {
+	v := reflect.ValueOf(stats.ApmServer)
+	for _, prefix := range prefixArray {
+		if v.Kind() == reflect.Struct {
+			v = v.FieldByName(prefix)
+		} else {
+			return v.Interface().(float64)
+		}
+	}
+	return v.Interface().(float64)
+}
+
+// Format the metric name - used to transform Struct names (Capitalized) into lowercase format
+func formatMetricName(name string) string {
+	return strings.ToLower(name)
+}

--- a/collector/apm_server_structs.go
+++ b/collector/apm_server_structs.go
@@ -1,0 +1,291 @@
+package collector
+
+type ApmServer struct {
+	Acm struct {
+		Request struct {
+			Count float64 `json:"count"`
+		} `json:"request"`
+		Response struct {
+			Count  float64 `json:"count"`
+			Errors struct {
+				Closed       float64 `json:"closed"`
+				Count        float64 `json:"count"`
+				Decode       float64 `json:"decode"`
+				Forbidden    float64 `json:"forbidden"`
+				Internal     float64 `json:"internal"`
+				Invalidquery float64 `json:"invalidquery"`
+				Method       float64 `json:"method"`
+				Notfound     float64 `json:"notfound"`
+				Queue        float64 `json:"queue"`
+				Ratelimit    float64 `json:"ratelimit"`
+				Toolarge     float64 `json:"toolarge"`
+				Unauthorized float64 `json:"unauthorized"`
+				Unavailable  float64 `json:"unavailable"`
+				Validate     float64 `json:"validate"`
+			} `json:"errors"`
+			Valid struct {
+				Accepted    float64 `json:"accepted"`
+				Count       float64 `json:"count"`
+				Notmodified float64 `json:"notmodified"`
+				Ok          float64 `json:"ok"`
+			} `json:"valid"`
+		} `json:"response"`
+		Unset float64 `json:"unset"`
+	} `json:"acm"`
+	Decoder struct {
+		Deflate struct {
+			ContentLength float64 `json:"content-length"`
+			Count         float64 `json:"count"`
+		} `json:"deflate"`
+		Gzip struct {
+			ContentLength float64 `json:"content-length"`
+			Count         float64 `json:"count"`
+		} `json:"gzip"`
+		MissingContentLength struct {
+			Count float64 `json:"count"`
+		} `json:"missing-content-length"`
+		Reader struct {
+			Count float64 `json:"count"`
+		} `json:"reader"`
+		Uncompressed struct {
+			ContentLength float64 `json:"content-length"`
+			Count         float64 `json:"count"`
+		} `json:"uncompressed"`
+	} `json:"decoder"`
+	Jaeger struct {
+		Grpc struct {
+			Collect struct {
+				Event struct {
+					Dropped struct {
+						Count float64 `json:"count"`
+					} `json:"dropped"`
+					Received struct {
+						Count float64 `json:"count"`
+					} `json:"received"`
+				} `json:"event"`
+				Request struct {
+					Count float64 `json:"count"`
+				} `json:"request"`
+				Response struct {
+					Count  float64 `json:"count"`
+					Errors struct {
+						Count float64 `json:"count"`
+					} `json:"errors"`
+					Valid struct {
+						Count float64 `json:"count"`
+					} `json:"valid"`
+				} `json:"response"`
+			} `json:"collect"`
+			Sampling struct {
+				Event struct {
+					Dropped struct {
+						Count float64 `json:"count"`
+					} `json:"dropped"`
+					Received struct {
+						Count float64 `json:"count"`
+					} `json:"received"`
+				} `json:"event"`
+				Request struct {
+					Count float64 `json:"count"`
+				} `json:"request"`
+				Response struct {
+					Count  float64 `json:"count"`
+					Errors struct {
+						Count float64 `json:"count"`
+					} `json:"errors"`
+					Valid struct {
+						Count float64 `json:"count"`
+					} `json:"valid"`
+				} `json:"response"`
+			} `json:"sampling"`
+		} `json:"grpc"`
+		HTTP struct {
+			Event struct {
+				Dropped struct {
+					Count float64 `json:"count"`
+				} `json:"dropped"`
+				Received struct {
+					Count float64 `json:"count"`
+				} `json:"received"`
+			} `json:"event"`
+			Request struct {
+				Count float64 `json:"count"`
+			} `json:"request"`
+			Response struct {
+				Count  float64 `json:"count"`
+				Errors struct {
+					Count float64 `json:"count"`
+				} `json:"errors"`
+				Valid struct {
+					Count float64 `json:"count"`
+				} `json:"valid"`
+			} `json:"response"`
+		} `json:"http"`
+	} `json:"jaeger"`
+	Processor struct {
+		Error struct {
+			Frames          float64 `json:"frames"`
+			Stacktraces     float64 `json:"stacktraces"`
+			Transformations float64 `json:"transformations"`
+		} `json:"error"`
+		Metric struct {
+			Transformations float64 `json:"transformations"`
+		} `json:"metric"`
+		Sourcemap struct {
+			Counter  float64 `json:"counter"`
+			Decoding struct {
+				Count  float64 `json:"count"`
+				Errors float64 `json:"errors"`
+			} `json:"decoding"`
+			Validation struct {
+				Count  float64 `json:"count"`
+				Errors float64 `json:"errors"`
+			} `json:"validation"`
+		} `json:"sourcemap"`
+		Span struct {
+			Frames          float64 `json:"frames"`
+			Stacktraces     float64 `json:"stacktraces"`
+			Transformations float64 `json:"transformations"`
+		} `json:"span"`
+		Stream struct {
+			Accepted float64 `json:"accepted"`
+			Errors   struct {
+				Closed   float64 `json:"closed"`
+				Invalid  float64 `json:"invalid"`
+				Queue    float64 `json:"queue"`
+				Server   float64 `json:"server"`
+				Toolarge float64 `json:"toolarge"`
+			} `json:"errors"`
+		} `json:"stream"`
+		Transaction struct {
+			Transformations float64 `json:"transformations"`
+		} `json:"transaction"`
+	} `json:"processor"`
+	Profile struct {
+		Request struct {
+			Count float64 `json:"count"`
+		} `json:"request"`
+		Response struct {
+			Count  float64 `json:"count"`
+			Errors struct {
+				Closed       float64 `json:"closed"`
+				Count        float64 `json:"count"`
+				Decode       float64 `json:"decode"`
+				Forbidden    float64 `json:"forbidden"`
+				Internal     float64 `json:"internal"`
+				Invalidquery float64 `json:"invalidquery"`
+				Method       float64 `json:"method"`
+				Notfound     float64 `json:"notfound"`
+				Queue        float64 `json:"queue"`
+				Ratelimit    float64 `json:"ratelimit"`
+				Toolarge     float64 `json:"toolarge"`
+				Unauthorized float64 `json:"unauthorized"`
+				Unavailable  float64 `json:"unavailable"`
+				Validate     float64 `json:"validate"`
+			} `json:"errors"`
+			Valid struct {
+				Accepted    float64 `json:"accepted"`
+				Count       float64 `json:"count"`
+				Notmodified float64 `json:"notmodified"`
+				Ok          float64 `json:"ok"`
+			} `json:"valid"`
+		} `json:"response"`
+		Unset float64 `json:"unset"`
+	} `json:"profile"`
+	Root struct {
+		Request struct {
+			Count float64 `json:"count"`
+		} `json:"request"`
+		Response struct {
+			Count  float64 `json:"count"`
+			Errors struct {
+				Closed       float64 `json:"closed"`
+				Count        float64 `json:"count"`
+				Decode       float64 `json:"decode"`
+				Forbidden    float64 `json:"forbidden"`
+				Internal     float64 `json:"internal"`
+				Invalidquery float64 `json:"invalidquery"`
+				Method       float64 `json:"method"`
+				Notfound     float64 `json:"notfound"`
+				Queue        float64 `json:"queue"`
+				Ratelimit    float64 `json:"ratelimit"`
+				Toolarge     float64 `json:"toolarge"`
+				Unauthorized float64 `json:"unauthorized"`
+				Unavailable  float64 `json:"unavailable"`
+				Validate     float64 `json:"validate"`
+			} `json:"errors"`
+			Valid struct {
+				Accepted    float64 `json:"accepted"`
+				Count       float64 `json:"count"`
+				Notmodified float64 `json:"notmodified"`
+				Ok          float64 `json:"ok"`
+			} `json:"valid"`
+		} `json:"response"`
+		Unset float64 `json:"unset"`
+	} `json:"root"`
+	Sampling struct {
+		TransactionsDropped float64 `json:"transactions_dropped"`
+	} `json:"sampling"`
+	Server struct {
+		Request struct {
+			Count float64 `json:"count"`
+		} `json:"request"`
+		Response struct {
+			Count  float64 `json:"count"`
+			Errors struct {
+				Closed       float64 `json:"closed"`
+				Count        float64 `json:"count"`
+				Decode       float64 `json:"decode"`
+				Forbidden    float64 `json:"forbidden"`
+				Internal     float64 `json:"internal"`
+				Invalidquery float64 `json:"invalidquery"`
+				Method       float64 `json:"method"`
+				Notfound     float64 `json:"notfound"`
+				Queue        float64 `json:"queue"`
+				Ratelimit    float64 `json:"ratelimit"`
+				Toolarge     float64 `json:"toolarge"`
+				Unauthorized float64 `json:"unauthorized"`
+				Unavailable  float64 `json:"unavailable"`
+				Validate     float64 `json:"validate"`
+			} `json:"errors"`
+			Valid struct {
+				Accepted    float64 `json:"accepted"`
+				Count       float64 `json:"count"`
+				Notmodified float64 `json:"notmodified"`
+				Ok          float64 `json:"ok"`
+			} `json:"valid"`
+		} `json:"response"`
+		Unset float64 `json:"unset"`
+	} `json:"server"`
+	Sourcemap struct {
+		Request struct {
+			Count float64 `json:"count"`
+		} `json:"request"`
+		Response struct {
+			Count  float64 `json:"count"`
+			Errors struct {
+				Closed       float64 `json:"closed"`
+				Count        float64 `json:"count"`
+				Decode       float64 `json:"decode"`
+				Forbidden    float64 `json:"forbidden"`
+				Internal     float64 `json:"internal"`
+				Invalidquery float64 `json:"invalidquery"`
+				Method       float64 `json:"method"`
+				Notfound     float64 `json:"notfound"`
+				Queue        float64 `json:"queue"`
+				Ratelimit    float64 `json:"ratelimit"`
+				Toolarge     float64 `json:"toolarge"`
+				Unauthorized float64 `json:"unauthorized"`
+				Unavailable  float64 `json:"unavailable"`
+				Validate     float64 `json:"validate"`
+			} `json:"errors"`
+			Valid struct {
+				Accepted    float64 `json:"accepted"`
+				Count       float64 `json:"count"`
+				Notmodified float64 `json:"notmodified"`
+				Ok          float64 `json:"ok"`
+			} `json:"valid"`
+		} `json:"response"`
+		Unset float64 `json:"unset"`
+	} `json:"sourcemap"`
+}

--- a/collector/apm_server_structs.go
+++ b/collector/apm_server_structs.go
@@ -1,5 +1,7 @@
 package collector
 
+// Generated using https://mholt.github.io/json-to-go/
+
 type ApmServer struct {
 	Acm struct {
 		Request struct {

--- a/collector/auditd.go
+++ b/collector/auditd.go
@@ -26,7 +26,7 @@ func NewAuditdCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 		metrics: exportedMetrics{
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "auditd", "kernel_lost"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "auditd", "kernel_lost"),
 					"auditd.kernel_lost",
 					nil, nil,
 				),
@@ -37,7 +37,7 @@ func NewAuditdCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "auditd", "reassembler_seq_gaps"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "auditd", "reassembler_seq_gaps"),
 					"auditd.reassembler_seq_gaps",
 					nil, nil,
 				),
@@ -48,7 +48,7 @@ func NewAuditdCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "auditd", "received_msgs"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "auditd", "received_msgs"),
 					"auditd.received_msgs",
 					nil, nil,
 				),
@@ -59,7 +59,7 @@ func NewAuditdCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "auditd", "userspace_lost"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "auditd", "userspace_lost"),
 					"auditd.userspace_lost",
 					nil, nil,
 				),

--- a/collector/beat.go
+++ b/collector/beat.go
@@ -56,7 +56,7 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 		metrics: exportedMetrics{
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "cpu_time", "seconds_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "cpu_time", "seconds_total"),
 					"beat.cpu.time",
 					nil, prometheus.Labels{"mode": "system"},
 				),
@@ -67,7 +67,7 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "cpu_time", "seconds_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "cpu_time", "seconds_total"),
 					"beat.cpu.time",
 					nil, prometheus.Labels{"mode": "user"},
 				),
@@ -78,7 +78,7 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "cpu", "ticks_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "cpu", "ticks_total"),
 					"beat.cpu.ticks",
 					nil, prometheus.Labels{"mode": "system"},
 				),
@@ -87,7 +87,7 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "cpu", "ticks_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "cpu", "ticks_total"),
 					"beat.cpu.ticks",
 					nil, prometheus.Labels{"mode": "user"},
 				),
@@ -96,7 +96,7 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "uptime", "seconds_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "uptime", "seconds_total"),
 					"beat.info.uptime.ms",
 					nil, nil,
 				),
@@ -107,7 +107,7 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "memstats", "gc_next_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "memstats", "gc_next_total"),
 					"beat.memstats.gc_next",
 					nil, nil,
 				),
@@ -118,7 +118,7 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "memstats", "memory_alloc"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "memstats", "memory_alloc"),
 					"beat.memstats.memory_alloc",
 					nil, nil,
 				),
@@ -129,7 +129,7 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "memstats", "memory"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "memstats", "memory"),
 					"beat.memstats.memory_total",
 					nil, nil,
 				),
@@ -140,7 +140,7 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "memstats", "rss"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "memstats", "rss"),
 					"beat.memstats.rss",
 					nil, nil,
 				),
@@ -151,7 +151,7 @@ func NewBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "runtime", "goroutines"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "runtime", "goroutines"),
 					"beat.runtime.goroutines",
 					nil, nil,
 				),

--- a/collector/filebeat.go
+++ b/collector/filebeat.go
@@ -44,7 +44,7 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 		metrics: exportedMetrics{
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "filebeat", "events"),
 					"filebeat.events",
 					nil, prometheus.Labels{"event": "active"},
 				),
@@ -53,7 +53,7 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "filebeat", "events"),
 					"filebeat.events",
 					nil, prometheus.Labels{"event": "added"},
 				),
@@ -62,7 +62,7 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "filebeat", "events"),
 					"filebeat.events",
 					nil, prometheus.Labels{"event": "done"},
 				),
@@ -71,7 +71,7 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "harvester"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "filebeat", "harvester"),
 					"filebeat.harvester",
 					nil, prometheus.Labels{"harvester": "closed"},
 				),
@@ -80,7 +80,7 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "harvester"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "filebeat", "harvester"),
 					"filebeat.harvester",
 					nil, prometheus.Labels{"harvester": "open_files"},
 				),
@@ -89,7 +89,7 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "harvester"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "filebeat", "harvester"),
 					"filebeat.harvester",
 					nil, prometheus.Labels{"harvester": "running"},
 				),
@@ -98,7 +98,7 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "harvester"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "filebeat", "harvester"),
 					"filebeat.harvester",
 					nil, prometheus.Labels{"harvester": "skipped"},
 				),
@@ -107,7 +107,7 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "harvester"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "filebeat", "harvester"),
 					"filebeat.harvester",
 					nil, prometheus.Labels{"harvester": "started"},
 				),
@@ -116,7 +116,7 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "input_log"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "filebeat", "input_log"),
 					"filebeat.input_log",
 					nil, prometheus.Labels{"files": "renamed"},
 				),
@@ -125,7 +125,7 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "input_log"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "filebeat", "input_log"),
 					"filebeat.input_log",
 					nil, prometheus.Labels{"files": "truncated"},
 				),

--- a/collector/libbeat.go
+++ b/collector/libbeat.go
@@ -70,7 +70,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 		metrics: exportedMetrics{
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat_config", "reloads_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat_config", "reloads_total"),
 					"libbeat.config.reloads",
 					nil, nil,
 				),
@@ -81,7 +81,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "config"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "config"),
 					"libbeat.config.module",
 					nil, prometheus.Labels{"module": "running"},
 				),
@@ -92,7 +92,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "config"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "config"),
 					"libbeat.config.module",
 					nil, prometheus.Labels{"module": "starts"},
 				),
@@ -103,7 +103,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "config"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "config"),
 					"libbeat.config.module",
 					nil, prometheus.Labels{"module": "stops"},
 				),
@@ -114,7 +114,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "output_read_bytes_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "output_read_bytes_total"),
 					"libbeat.output.read.bytes",
 					nil, nil,
 				),
@@ -125,7 +125,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "output_read_errors_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "output_read_errors_total"),
 					"libbeat.output.read.errors",
 					nil, nil,
 				),
@@ -136,7 +136,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "output_write_bytes_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "output_write_bytes_total"),
 					"libbeat.output.write.bytes",
 					nil, nil,
 				),
@@ -147,7 +147,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "output_write_errors_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "output_write_errors_total"),
 					"libbeat.output.write.errors",
 					nil, nil,
 				),
@@ -158,7 +158,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "output_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "output_events"),
 					"libbeat.output.events",
 					nil, prometheus.Labels{"type": "acked"},
 				),
@@ -169,7 +169,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "output_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "output_events"),
 					"libbeat.output.events",
 					nil, prometheus.Labels{"type": "active"},
 				),
@@ -180,7 +180,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "output_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "output_events"),
 					"libbeat.output.events",
 					nil, prometheus.Labels{"type": "batches"},
 				),
@@ -191,7 +191,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "output_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "output_events"),
 					"libbeat.output.events",
 					nil, prometheus.Labels{"type": "dropped"},
 				),
@@ -202,7 +202,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "output_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "output_events"),
 					"libbeat.output.events",
 					nil, prometheus.Labels{"type": "duplicates"},
 				),
@@ -213,7 +213,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "output_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "output_events"),
 					"libbeat.output.events",
 					nil, prometheus.Labels{"type": "failed"},
 				),
@@ -224,7 +224,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "pipeline_clients"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "pipeline_clients"),
 					"libbeat.pipeline.clients",
 					nil, nil,
 				),
@@ -235,7 +235,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "pipeline_queue"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "pipeline_queue"),
 					"libbeat.pipeline.queue",
 					nil, prometheus.Labels{"type": "acked"},
 				),
@@ -246,7 +246,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "pipeline_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "pipeline_events"),
 					"libbeat.pipeline.events",
 					nil, prometheus.Labels{"type": "active"},
 				),
@@ -257,7 +257,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "pipeline_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "pipeline_events"),
 					"libbeat.pipeline.events",
 					nil, prometheus.Labels{"type": "dropped"},
 				),
@@ -268,7 +268,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "pipeline_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "pipeline_events"),
 					"libbeat.pipeline.events",
 					nil, prometheus.Labels{"type": "failed"},
 				),
@@ -279,7 +279,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "pipeline_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "pipeline_events"),
 					"libbeat.pipeline.events",
 					nil, prometheus.Labels{"type": "filtered"},
 				),
@@ -290,7 +290,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "pipeline_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "pipeline_events"),
 					"libbeat.pipeline.events",
 					nil, prometheus.Labels{"type": "published"},
 				),
@@ -301,7 +301,7 @@ func NewLibBeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector 
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "libbeat", "pipeline_events"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "libbeat", "pipeline_events"),
 					"libbeat.pipeline.events",
 					nil, prometheus.Labels{"type": "retry"},
 				),
@@ -322,7 +322,7 @@ func (c *libbeatCollector) Describe(ch chan<- *prometheus.Desc) {
 	}
 
 	libbeatOutputType = prometheus.NewDesc(
-		prometheus.BuildFQName(c.beatInfo.Beat, "libbeat", "output_total"),
+		prometheus.BuildFQName(c.beatInfo.FormattedBeat(), "libbeat", "output_total"),
 		"libbeat.output.type",
 		[]string{"type"}, nil,
 	)

--- a/collector/main.go
+++ b/collector/main.go
@@ -41,9 +41,9 @@ func NewMainCollector(client *http.Client, url *url.URL, name string, beatInfo *
 			prometheus.BuildFQName(name, "target", "info"),
 			"target information",
 			nil,
-			prometheus.Labels{"version": beatInfo.Version, "beat": beatInfo.Beat, "uri": instance}),
+			prometheus.Labels{"version": beatInfo.Version, "beat": beatInfo.FormattedBeat(), "uri": instance}),
 		targetUp: prometheus.NewDesc(
-			prometheus.BuildFQName("", beatInfo.Beat, "up"),
+			prometheus.BuildFQName("", beatInfo.FormattedBeat(), "up"),
 			"Target up",
 			nil,
 			nil),
@@ -60,6 +60,7 @@ func NewMainCollector(client *http.Client, url *url.URL, name string, beatInfo *
 	beat.Collectors["filebeat"] = NewFilebeatCollector(beatInfo, beat.Stats)
 	beat.Collectors["metricbeat"] = NewMetricbeatCollector(beatInfo, beat.Stats)
 	beat.Collectors["auditd"] = NewAuditdCollector(beatInfo, beat.Stats)
+	beat.Collectors["apm_server"] = NewApmServerCollector(beatInfo, beat.Stats)
 
 	return beat
 }
@@ -88,6 +89,8 @@ func (b *mainCollector) Describe(ch chan<- *prometheus.Desc) {
 		b.Collectors["registrar"].Describe(ch)
 	case "metricbeat":
 		b.Collectors["metricbeat"].Describe(ch)
+	case "apm-server":
+		b.Collectors["apm_server"].Describe(ch)
 	}
 
 }
@@ -124,6 +127,8 @@ func (b *mainCollector) Collect(ch chan<- prometheus.Metric) {
 		b.Collectors["registrar"].Collect(ch)
 	case "metricbeat":
 		b.Collectors["metricbeat"].Collect(ch)
+	case "apm-server":
+		b.Collectors["apm_server"].Collect(ch)
 	}
 
 }

--- a/collector/metricbeat.go
+++ b/collector/metricbeat.go
@@ -39,7 +39,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 		metrics: exportedMetrics{
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "cpu"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "cpu"),
 					"system.cpu",
 					nil, prometheus.Labels{"event": "success"},
 				),
@@ -48,7 +48,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "cpu"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "cpu"),
 					"system.cpu",
 					nil, prometheus.Labels{"event": "failures"},
 				),
@@ -57,7 +57,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "filesystem"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "filesystem"),
 					"system.filesystem",
 					nil, prometheus.Labels{"event": "success"},
 				),
@@ -66,7 +66,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "filesystem"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "filesystem"),
 					"system.filesystem",
 					nil, prometheus.Labels{"event": "failures"},
 				),
@@ -75,7 +75,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "fsstat"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "fsstat"),
 					"system.fsstat",
 					nil, prometheus.Labels{"event": "success"},
 				),
@@ -84,7 +84,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "fsstat"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "fsstat"),
 					"system.fsstat",
 					nil, prometheus.Labels{"event": "failures"},
 				),
@@ -93,7 +93,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "load"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "load"),
 					"system.load",
 					nil, prometheus.Labels{"event": "success"},
 				),
@@ -102,7 +102,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "load"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "load"),
 					"system.load",
 					nil, prometheus.Labels{"event": "failures"},
 				),
@@ -111,7 +111,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "memory"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "memory"),
 					"system.memory",
 					nil, prometheus.Labels{"event": "success"},
 				),
@@ -120,7 +120,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "memory"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "memory"),
 					"system.memory",
 					nil, prometheus.Labels{"event": "failures"},
 				),
@@ -129,7 +129,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "network"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "network"),
 					"system.network",
 					nil, prometheus.Labels{"event": "success"},
 				),
@@ -138,7 +138,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "network"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "network"),
 					"system.network",
 					nil, prometheus.Labels{"event": "failures"},
 				),
@@ -147,7 +147,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "process"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "process"),
 					"system.process",
 					nil, prometheus.Labels{"event": "success"},
 				),
@@ -156,7 +156,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "process"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "process"),
 					"system.process",
 					nil, prometheus.Labels{"event": "failures"},
 				),
@@ -165,7 +165,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "process_summary"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "process_summary"),
 					"system.process_summary",
 					nil, prometheus.Labels{"event": "success"},
 				),
@@ -174,7 +174,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "process_summary"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "process_summary"),
 					"system.process_summary",
 					nil, prometheus.Labels{"event": "failures"},
 				),
@@ -183,7 +183,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "uptime"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "uptime"),
 					"system.uptime",
 					nil, prometheus.Labels{"event": "success"},
 				),
@@ -192,7 +192,7 @@ func NewMetricbeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collect
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "metricbeat_system", "uptime"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "metricbeat_system", "uptime"),
 					"system.uptime",
 					nil, prometheus.Labels{"event": "failures"},
 				),

--- a/collector/registrar.go
+++ b/collector/registrar.go
@@ -32,7 +32,7 @@ func NewRegistrarCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collecto
 		metrics: exportedMetrics{
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "registrar", "writes"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "registrar", "writes"),
 					"registrar.writes",
 					nil, prometheus.Labels{"writes": "fail"},
 				),
@@ -41,7 +41,7 @@ func NewRegistrarCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collecto
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "registrar", "writes"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "registrar", "writes"),
 					"registrar.writes",
 					nil, prometheus.Labels{"writes": "success"},
 				),
@@ -50,7 +50,7 @@ func NewRegistrarCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collecto
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "registrar", "writes"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "registrar", "writes"),
 					"registrar.writes",
 					nil, prometheus.Labels{"writes": "total"},
 				),
@@ -59,7 +59,7 @@ func NewRegistrarCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collecto
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "registrar", "states"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "registrar", "states"),
 					"registrar.states",
 					nil, prometheus.Labels{"state": "cleanup"},
 				),
@@ -68,7 +68,7 @@ func NewRegistrarCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collecto
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "registrar", "states"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "registrar", "states"),
 					"registrar.states",
 					nil, prometheus.Labels{"state": "current"},
 				),
@@ -77,7 +77,7 @@ func NewRegistrarCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collecto
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "registrar", "states"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "registrar", "states"),
 					"registrar.states",
 					nil, prometheus.Labels{"state": "update"},
 				),

--- a/collector/structs.go
+++ b/collector/structs.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"strings"
 )
 
 //BeatInfo beat info json structure
@@ -21,11 +22,19 @@ type Stats struct {
 	Registrar  Registrar   `json:"registrar"`
 	Filebeat   Filebeat    `json:"filebeat"`
 	Metricbeat Metricbeat  `json:"metricbeat"`
+	ApmServer  ApmServer   `json:"apm-server"`
 	Auditd     AuditdStats `json:"auditd"`
 }
 
-type exportedMetrics []struct {
+type exportedMetrics []exportedMetric
+
+type exportedMetric struct {
 	desc    *prometheus.Desc
 	eval    func(stats *Stats) float64
 	valType prometheus.ValueType
+}
+
+// Name receives a copy of Foo since it doesn't need to modify it.
+func (beatInfo BeatInfo) FormattedBeat() string {
+	return strings.Replace(beatInfo.Beat, "-", "_", -1)
 }

--- a/collector/structs.go
+++ b/collector/structs.go
@@ -34,7 +34,7 @@ type exportedMetric struct {
 	valType prometheus.ValueType
 }
 
-// Name receives a copy of Foo since it doesn't need to modify it.
+// Formats the beat name to a form accaptable as part of the metric name (e.g. apm-server -> apm_server)
 func (beatInfo BeatInfo) FormattedBeat() string {
 	return strings.Replace(beatInfo.Beat, "-", "_", -1)
 }

--- a/collector/structs.go
+++ b/collector/structs.go
@@ -34,7 +34,7 @@ type exportedMetric struct {
 	valType prometheus.ValueType
 }
 
-// Formats the beat name to a form accaptable as part of the metric name (e.g. apm-server -> apm_server)
+// Formats the beat name to a form acceptable as part of the metric name (e.g. apm-server -> apm_server)
 func (beatInfo BeatInfo) FormattedBeat() string {
 	return strings.Replace(beatInfo.Beat, "-", "_", -1)
 }

--- a/collector/system.go
+++ b/collector/system.go
@@ -35,7 +35,7 @@ func NewSystemCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 		metrics: exportedMetrics{
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "system_cpu", "cores_total"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "system_cpu", "cores_total"),
 					"cpu cores",
 					nil, nil,
 				),
@@ -44,7 +44,7 @@ func NewSystemCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "system", "load"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "system", "load"),
 					"system load",
 					nil, prometheus.Labels{"period": "1"},
 				),
@@ -53,7 +53,7 @@ func NewSystemCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "system", "load"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "system", "load"),
 					"system load",
 					nil, prometheus.Labels{"period": "5"},
 				),
@@ -62,7 +62,7 @@ func NewSystemCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "system", "load"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "system", "load"),
 					"system load",
 					nil, prometheus.Labels{"period": "15"},
 				),
@@ -71,7 +71,7 @@ func NewSystemCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "system_load", "norm"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "system_load", "norm"),
 					"system load",
 					nil, prometheus.Labels{"period": "1"},
 				),
@@ -80,7 +80,7 @@ func NewSystemCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "system_load", "norm"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "system_load", "norm"),
 					"system load",
 					nil, prometheus.Labels{"period": "5"},
 				),
@@ -89,7 +89,7 @@ func NewSystemCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector {
 			},
 			{
 				desc: prometheus.NewDesc(
-					prometheus.BuildFQName(beatInfo.Beat, "system_load", "norm"),
+					prometheus.BuildFQName(beatInfo.FormattedBeat(), "system_load", "norm"),
 					"system load",
 					nil, prometheus.Labels{"period": "15"},
 				),

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ beatdiscovery:
 
 	log.WithFields(log.Fields{
 		"addr": *listenAddress,
-	}).Infof("Starting exporter with configured type: %s", beatInfo.Beat)
+	}).Infof("Starting exporter with configured type: %s", beatInfo.FormattedBeat())
 
 	go func() {
 		defer func() {
@@ -215,7 +215,7 @@ func loadBeatType(client *http.Client, url url.URL) (*collector.BeatInfo, error)
 
 	log.WithFields(
 		log.Fields{
-			"beat":     beatInfo.Beat,
+			"beat":     beatInfo.FormattedBeat(),
 			"version":  beatInfo.Version,
 			"name":     beatInfo.Name,
 			"hostname": beatInfo.Hostname,

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Current coverage
 
  * filebeat
  * metricbeat
+ * apm-server
  * packetbeat - _partial_
  * auditbeat - _partial_
 


### PR DESCRIPTION
This PR adds the full (as of APM server v7.10.1) support with all the APM Server metrics exported. Alongside with the addition of APM-server-specific metrics, the general issue with the APM server beat name (name containing "_-_" between _apm_ and _server_) has been fixed.

Feature successfully tested with APM server v7.10.1, other versions are yet to be tested, but considering the size of this change, I would like to start with feedback loops. 
I will also test the metric and filebeats for potential regression. I will post the results here.

Closes #42 