### PR TITLE
Adds support for Netflow input metrics

### DIFF
--- a/collector/filebeat.go
+++ b/collector/filebeat.go
@@ -27,6 +27,14 @@ type Filebeat struct {
 				Truncated float64 `json:"truncated"`
 			} `json:"files"`
 		} `json:"log"`
+
+		Netflow struct {
+			Flows   float64 `json:"flows"`
+			Packets struct {
+				Received float64 `json:"received"`
+				Dropped  float64 `json:"dropped"`
+			} `json:"packets"`
+		} `json:"netflow"`
 	} `json:"input"`
 }
 
@@ -130,6 +138,33 @@ func NewFilebeatCollector(beatInfo *BeatInfo, stats *Stats) prometheus.Collector
 					nil, prometheus.Labels{"files": "truncated"},
 				),
 				eval:    func(stats *Stats) float64 { return stats.Filebeat.Input.Log.Files.Truncated },
+				valType: prometheus.UntypedValue,
+			},
+			{
+				desc: prometheus.NewDesc(
+					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "input_netflow"),
+					"filebeat.input_netflow",
+					nil, prometheus.Labels{"netflow": "flows"},
+				),
+				eval:    func(stats *Stats) float64 { return stats.Filebeat.Input.Netflow.Flows },
+				valType: prometheus.UntypedValue,
+			},
+			{
+				desc: prometheus.NewDesc(
+					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "input_netflow"),
+					"filebeat.input_netflow",
+					nil, prometheus.Labels{"netflow": "packets_received"},
+				),
+				eval:    func(stats *Stats) float64 { return stats.Filebeat.Input.Netflow.Packets.Received },
+				valType: prometheus.UntypedValue,
+			},
+			{
+				desc: prometheus.NewDesc(
+					prometheus.BuildFQName(beatInfo.Beat, "filebeat", "input_netflow"),
+					"filebeat.input_netflow",
+					nil, prometheus.Labels{"netflow": "packets_dropped"},
+				),
+				eval:    func(stats *Stats) float64 { return stats.Filebeat.Input.Netflow.Packets.Dropped },
 				valType: prometheus.UntypedValue,
 			},
 		},


### PR DESCRIPTION
Hi,
Thank you for creating the exporter. 
This PR adds additional metrics for the Netflow input: 
- Flows
- Packets received
- Packets dropped

The definition of these metrics in beats can be found here: https://github.com/elastic/beats/blob/c43db8ce74d6dac1da04abb770c0d2abbed43015/x-pack/filebeat/input/netflow/input.go#L34-L36