### PR TITLE
Add support for FreeBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
-if [[ -z "$GITHUB_WORKSPACE" ]]; then
+if [ -z "$GITHUB_WORKSPACE" ]; then
   GITHUB_WORKSPACE=$(pwd)
   echo "Setting up GITHUB_WORKSPACE to current directory: ${GITHUB_WORKSPACE}"
 fi
 
-if [[ -z "$GITHUB_ACTOR" ]]; then
+if [ -z "$GITHUB_ACTOR" ]; then
   GITHUB_ACTOR=$(whoami)
   echo "Setting up GITHUB_ACTOR to current user: ${GITHUB_ACTOR}"
 fi
@@ -25,7 +25,7 @@ LDFLAGS="-s -X github.com/prometheus/common/version.Version=${GITVERSION} \
 for OS in "darwin" "linux" "windows" "freebsd"; do
     for ARCH in "amd64" "386"; do 
         echo "Building ${OS}/${ARCH} with version: ${GITVERSION}, revision: ${GITREVISION}, buildUser: ${GITHUB_ACTOR}"
-        if [[ $OS == "windows" ]]; then
+        if [ $OS == "windows" ]; then
             GO111MODULE=on CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "${LDFLAGS}" -tags 'netgo static_build' -a -o ".build/${OS}-${ARCH}/beat-exporter.exe"
         else 
             GO111MODULE=on CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "${LDFLAGS}" -tags 'netgo static_build' -a -o ".build/${OS}-${ARCH}/beat-exporter"

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ LDFLAGS="-s -X github.com/prometheus/common/version.Version=${GITVERSION} \
 -X github.com/prometheus/common/version.BuildUser=${GITHUB_ACTOR} \
 -X github.com/prometheus/common/version.BuildDate=${TIME}"
 
-for OS in "darwin" "linux" "windows"; do
+for OS in "darwin" "linux" "windows" "freebsd"; do
     for ARCH in "amd64" "386"; do 
         echo "Building ${OS}/${ARCH} with version: ${GITVERSION}, revision: ${GITREVISION}, buildUser: ${GITHUB_ACTOR}"
         if [[ $OS == "windows" ]]; then

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+//go:build linux || darwin || freebsd
 
 package service
 


### PR DESCRIPTION
### What ⁉️
Small changes to add ability to build on FreeBSD.

### Why ⁉️
To use it on FreeBSD. 😇

### How ⁉️
I don't know no Go, so I just added a keyword in a file and got lucky.

### How to review and test 📱
I think changes are small and straightforward enough not to need specific review,  but YMMV.

I just tested it on FreeBSD/amd64:

```sh
$ .build/freebsd-amd64/beat-exporter
{"level":"info","message":"Exploring target for beat type","time":"2023-10-12T14:57:30+02:00"}
{"beat":"filebeat","hostname":"c2s.dev.andxor.it","level":"info","message":"Target beat configuration loaded successfully!","name":"c2s.dev.andxor.it","time":"2023-10-12T14:57:31+02:00","uuid":"1b280254-5562-4ce6-86db-900f6158d590","version":"7.17.11"}
$ % xh http://localhost:9479/metrics | fgrep filebeat_runtime_goroutines
# HELP filebeat_runtime_goroutines beat.runtime.goroutines
# TYPE filebeat_runtime_goroutines gauge
filebeat_runtime_goroutines 31
```